### PR TITLE
fix compile error while returning object literal

### DIFF
--- a/contracts/staking-pool/assembly/index.ts
+++ b/contracts/staking-pool/assembly/index.ts
@@ -764,7 +764,7 @@ class VoteArgs {
 class ExtVoting extends ExtContract {
   static readonly VOTE_METHOD: string = "vote";
   static VoteArgs(is_vote: bool): VoteArgs {
-    return {is_vote}
+    return new VoteArgs(is_vote)
   }
 
   vote(is_vote:bool): ContractPromiseBatch {


### PR DESCRIPTION
@theophoric this was throwing an error on compile

```txt
ERROR AS216: Class 'contracts/staking-pool/assembly/index/VoteArgs' cannot declare a constructor when instantiated from an object literal.

     return {
      is_vote: is_vote
    }
            ^
 in contracts/staking-pool/assembly/index.ts(619,12)

   constructor(public is_vote: bool) {}
   ~~~~~~~~~~~
 in contracts/staking-pool/assembly/index.ts(575,3)

```